### PR TITLE
Add some extra strategies

### DIFF
--- a/AutoLineColor/AutoLineColor.csproj
+++ b/AutoLineColor/AutoLineColor.csproj
@@ -65,6 +65,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Coloring\RandomColorStrategy.cs" />
     <Compile Include="Coloring\RandomHueStrategy.cs" />
+    <Compile Include="Coloring\CategorisedColor.cs" />
+    <Compile Include="Coloring\CategorisedColorStrategy.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/AutoLineColor/AutoLineColor.csproj
+++ b/AutoLineColor/AutoLineColor.csproj
@@ -67,6 +67,8 @@
     <Compile Include="Coloring\RandomHueStrategy.cs" />
     <Compile Include="Coloring\CategorisedColor.cs" />
     <Compile Include="Coloring\CategorisedColorStrategy.cs" />
+    <Compile Include="Naming\LondonNamingStrategy.cs" />
+    <Compile Include="Naming\GenericNames.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/AutoLineColor/ColorMonitor.cs
+++ b/AutoLineColor/ColorMonitor.cs
@@ -25,6 +25,7 @@ namespace AutoLineColor
             Console.Message("loading auto color monitor");
             Console.Message("initializing colors");
             RandomColor.Initialize();
+            CategorisedColor.Initialize();
 
             Console.Message("loading current config");
             var config = Configuration.LoadConfig();
@@ -61,6 +62,8 @@ namespace AutoLineColor
                     return new RandomHueStrategy();
                 case ColorStrategy.RandomColor:
                     return new RandomColorStrategy();
+                case ColorStrategy.CategorisedColor:
+                    return new CategorisedColorStrategy();
                 default:
                     Console.Error("unknown color strategy");
                     return new RandomHueStrategy();

--- a/AutoLineColor/ColorMonitor.cs
+++ b/AutoLineColor/ColorMonitor.cs
@@ -26,6 +26,7 @@ namespace AutoLineColor
             Console.Message("initializing colors");
             RandomColor.Initialize();
             CategorisedColor.Initialize();
+            GenericNames.Initialize();
 
             Console.Message("loading current config");
             var config = Configuration.LoadConfig();
@@ -48,6 +49,8 @@ namespace AutoLineColor
                     return new NoNamingStrategy();
                 case NamingStrategy.Districts:
                     return new DistrictNamingStrategy();
+                case NamingStrategy.London:
+                    return new LondonNamingStrategy();
                 default:
                     Console.Error("unknown naming strategy");
                     return new NoNamingStrategy();

--- a/AutoLineColor/ColorMonitor.cs
+++ b/AutoLineColor/ColorMonitor.cs
@@ -161,10 +161,7 @@ namespace AutoLineColor
 
         public static bool IsActive(this TransportLine transportLine)
         {
-            if ((transportLine.m_flags & TransportLine.Flags.Created) != TransportLine.Flags.Created)
-                return false;
-
-            if ((transportLine.m_flags & TransportLine.Flags.Hidden) == TransportLine.Flags.Hidden)
+            if ((transportLine.m_flags & (TransportLine.Flags.Complete | TransportLine.Flags.Created | TransportLine.Flags.Hidden)) == 0)
                 return false;
 
             // stations are marked with this flag

--- a/AutoLineColor/ColorMonitor.cs
+++ b/AutoLineColor/ColorMonitor.cs
@@ -95,7 +95,7 @@ namespace AutoLineColor
                         continue;
 
                     // only worry about fully created lines 
-                    if (transportLine.IsActive() == false || (transportLine.HasCustomColor() && transportLine.HasCustomName()))
+                    if (!transportLine.IsActive() || transportLine.HasCustomName() || !transportLine.m_color.IsDefaultColor())
                         continue;
 
                     var lineName = _namingStrategy.GetName(transportLine);
@@ -103,7 +103,7 @@ namespace AutoLineColor
 
                     Console.Message(string.Format("New line found. {0} {1}", lineName, color));
 
-                    if (transportLine.HasCustomColor() == false || transportLine.m_color.IsColorEqual(new Color32(44,142,191,255)))
+                    if (!transportLine.HasCustomColor() || transportLine.m_color.IsDefaultColor())
                     {
                         // set the color
                         transportLine.m_color = color;
@@ -139,6 +139,18 @@ namespace AutoLineColor
 
     internal static class LineExtensions
     {
+        private static Color32 _defaultBusColor = new Color32(44,142,191,255);
+        private static Color32 _defaultMetroColor = new Color32(0,184,0,255);
+        private static Color32 _defaultTrainColor = new Color32(219,86,0,255);
+
+        public static bool IsDefaultColor(this Color32 color)
+        {
+            return (
+                color.IsColorEqual(_defaultBusColor) ||
+                color.IsColorEqual(_defaultMetroColor) ||
+                color.IsColorEqual(_defaultTrainColor));
+        }
+
         public static bool IsColorEqual(this Color32 color1, Color32 color2)
         {
             return (color1.r == color2.r && color1.g == color2.g && color1.b == color2.b && color1.a == color2.a);

--- a/AutoLineColor/Coloring/CategorisedColor.cs
+++ b/AutoLineColor/Coloring/CategorisedColor.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+/*
+ * Categorised coloring scheme
+ * ---------------------------
+ * 
+ * This scheme uses a deterministic categorised coloring scheme.
+ * 
+ * The basis is a set of 18 hues:
+ *   00EE20,Green
+ *   00FF8A Mint green
+ *   00FFC9 Turquoise
+ *   00E4FF Aqua
+ *   00ACFF Cornflower blue
+ *   006EFF Cerulean blue
+ *   0014FF Blue
+ *   4900FF Violet
+ *   9900FF Purple
+ *   EA00FF Magenta
+ *   FF00B4 Pink
+ *   FF005F Salmon
+ *   FF0300 Red
+ *   FF4500 Orangered
+ *   FFC000 Gold
+ *   FFF700 Yellow
+ *   A5FF00 Lawn green
+ *   60FF00 Lime green
+ * 
+ * These are transformed as follows:
+ *   Bus lines (pale):
+ *     Start from green, step 7 places each time
+ *     At first lightened by ~55%, then ~40%, then ~25%
+ *   Metro lines (bright):
+ *     Start from cerulean blue
+ *     At first as-is, and then darkened by 50%
+ *   Train lines (dark):
+ *     Start from orangered
+ *     Darkened by 75%
+ * 
+ * Once all colours of a particular category are exhausted, the sequence repeats.
+ */
+
+namespace AutoLineColor.Coloring
+{
+    class CategorisedColor
+    {
+        private const string DefaultBrightColors = "#00ee20, #4900ff, #ffc000, #00e4ff, #ff00b4, #60ff00, #0014ff, #ff4500, #00ffc9, #ea00ff, #a5ff00, #006eff, #ff0300, #00ff8a, #9900ff, #fff700, #00acff, #ff005f, #00a816, #3300b4, #b48700, #00a1b4, #b4007f, #43b400, #000eb4, #b43000, #00b48e, #a500b4, #74b400, #004db4, #b40200, #00b461, #6c00b4, #b4ae00, #0079b4, #b40043"; 
+        private const string DefaultPaleColors = "#bccaff, #ffbcbc, #bcffd2, #d6bcff, #fffbbc, #bcddff, #ffbcc6, #bcf7bd, #c2bcff, #ffe4bc, #bcf3ff, #ffbce0, #c7ffbc, #bcbcff, #ffc1bc, #bcffe8, #f5bcff, #daffbc, #a6baff, #ffa6a6, #a6ffc4, #cba6ff, #fffaa6, #a6d3ff, #ffa6b5, #a6f5a8, #afa6ff, #ffdda6, #a6efff, #ffa6d7, #b6ffa6, #a6a7ff, #ffaea6, #a6ffe1, #f3a6ff, #d0ffa6, #7f9eff, #ff7f7f, #7fffae, #b77fff, #fff97f, #7fc3ff, #ff7f97, #7ff282, #8d7fff, #ffd17f, #7feaff, #ff7fc9, #97ff7f, #7f80ff, #ff8c7f, #7fffd7, #ef7fff, #bfff7f";
+        private const string DefaultDarkColors = "#7f2200, #007f64, #75007f, #527f00, #00377f, #7f0100, #007f45, #4c007f, #7f7b00, #00567f, #7f002f, #007710, #24007f, #7f6000, #00727f, #7f005a, #307f00, #000a7f";
+
+
+        private static List<Color32> _bright_colors;
+        private static List<Color32> _pale_colors;
+        private static List<Color32> _dark_colors;
+        private static Color32 _black = new Color32(0, 0, 0, 255);
+
+        public static void Initialize()
+        {
+            _bright_colors = BuildColorList(DefaultBrightColors, "bright.txt");
+            _pale_colors = BuildColorList(DefaultPaleColors, "pale.txt");
+            _dark_colors = BuildColorList(DefaultDarkColors, "dark.txt");
+        }
+
+        private static List<Color32> BuildColorList(string defaultColorList, string fileName)
+        {
+            // we need to load the color list
+            var fullPath = Configuration.GetModFileName(fileName);
+            var unparsedColors = defaultColorList;
+
+            try
+            {
+                if (File.Exists(fullPath))
+                {
+                    unparsedColors = File.ReadAllText(fullPath);
+                }
+                else
+                {
+                    Console.Message("No colors found, writing default values to  " + fullPath);
+                    File.WriteAllText(fullPath, unparsedColors);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error("error reading colors from disk " + ex);
+            }
+
+            // split on new lines, commas and semi-colons
+            var colorHexValues = unparsedColors.Split(new[] { "\n", "\r", ",", ";" }, StringSplitOptions.RemoveEmptyEntries);
+            var colorList = new List<Color32>();
+            foreach (var colorHexValue in colorHexValues)
+            {
+                Color32 color;
+                if (TryHexToColor(colorHexValue, out color))
+                {
+                    colorList.Add(color);
+                }
+            }
+            return colorList;
+        }
+
+        private static bool TryHexToColor(string hex, out Color32 color)
+        {
+            try
+            {
+                hex = hex.Replace("0x", ""); //in case the string is formatted 0xFFFFFF
+                hex = hex.Replace("#", ""); //in case the string is formatted #FFFFFF
+                hex = hex.Trim();
+
+                byte alpha = 255; //assume fully visible unless specified in hex
+
+                var red = byte.Parse(hex.Substring(0, 2), NumberStyles.HexNumber);
+                var green = byte.Parse(hex.Substring(2, 2), NumberStyles.HexNumber);
+                var blue = byte.Parse(hex.Substring(4, 2), NumberStyles.HexNumber);
+
+                //Only use alpha if the string has enough characters
+                if (hex.Length == 8)
+                {
+                    alpha = byte.Parse(hex.Substring(4, 2), NumberStyles.HexNumber);
+                }
+
+                color = new Color32(red, green, blue, alpha);
+                return true;
+
+            }
+            catch (Exception)
+            {
+                color = _black;
+                return false;
+            }
+
+        }
+
+        private static Color32 GetColor(List<Color32> colors, List<Color32> usedColors)
+        {
+            var color = _black;
+            int usedCount = -1;
+            foreach (var candidateColor in colors)
+            {
+                int candidateUsedCount = 0;
+                if (usedColors != null)
+                {
+                    foreach (var usedColor in usedColors)
+                    {
+                        if (candidateColor.IsColorEqual(usedColor))
+                        {
+                            candidateUsedCount++;
+                        }
+                    }
+                }
+                if (usedCount == -1 || candidateUsedCount < usedCount)
+                {
+                    color = candidateColor;
+                    usedCount = candidateUsedCount;
+                }
+            }
+            return color;
+        }
+
+        public static Color32 GetBrightColor(List<Color32> usedColors)
+        {
+            return GetColor(_bright_colors, usedColors);
+        }
+
+        public static Color32 GetPaleColor(List<Color32> usedColors)
+        {
+            return GetColor(_pale_colors, usedColors);
+        }
+
+        public static Color32 GetDarkColor(List<Color32> usedColors)
+        {
+            return GetColor(_dark_colors, usedColors);
+        }
+    }
+}

--- a/AutoLineColor/Coloring/CategorisedColorStrategy.cs
+++ b/AutoLineColor/Coloring/CategorisedColorStrategy.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+using System.Linq;
+using System;
+
+namespace AutoLineColor.Coloring
+{
+    internal class CategorisedColorStrategy : IColorStrategy
+    {
+        public Color32 GetColor(TransportLine transportLine)
+        {
+            switch (transportLine.Info.m_transportType)
+            {
+                case TransportInfo.TransportType.Bus:
+                    return CategorisedColor.GetPaleColor(null);
+                case TransportInfo.TransportType.Metro:
+                    return CategorisedColor.GetBrightColor(null);
+                default:
+                    return CategorisedColor.GetDarkColor(null);
+            }
+        }
+
+
+        public Color32 GetColor(TransportLine transportLine, System.Collections.Generic.List<Color32> usedColors)
+        {
+            switch (transportLine.Info.m_transportType)
+            {
+                case TransportInfo.TransportType.Bus:
+                    return CategorisedColor.GetPaleColor(usedColors);
+                case TransportInfo.TransportType.Metro:
+                    return CategorisedColor.GetBrightColor(usedColors);
+                default:
+                    return CategorisedColor.GetDarkColor(usedColors);
+            }
+        }
+    }
+}

--- a/AutoLineColor/Configuration.cs
+++ b/AutoLineColor/Configuration.cs
@@ -81,7 +81,8 @@ namespace AutoLineColor
     public enum ColorStrategy
     {
         RandomHue,
-        RandomColor
+        RandomColor,
+        CategorisedColor
     }
 
     public enum NamingStrategy

--- a/AutoLineColor/Configuration.cs
+++ b/AutoLineColor/Configuration.cs
@@ -88,6 +88,7 @@ namespace AutoLineColor
     public enum NamingStrategy
     {
         None,
-        Districts
+        Districts,
+        London
     }
 }

--- a/AutoLineColor/Naming/GenericNames.cs
+++ b/AutoLineColor/Naming/GenericNames.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+
+namespace AutoLineColor
+{
+    public class GenericNames
+    {
+        private static string[] _names;
+        private const string defaultNames =
+            "Alpha,Bravo,Charlie,Delta,Echo,Foxtrot,Golf,Hotel,India,Juliet,Kilo,Lima,Mike," +
+            "November,Oscar,Papa,Quebec,Romeo,Sierra,Tango,Uniform,Victor,Whiskey,Yankee,Zulu," +
+            "Adams,Boston,Chicago,Denver,Easy,Frank,George,Henry,Ida,John,King,Lincoln,Mary," +
+            "New,Ocean,Peter,Queen,Roger,Sugar,Thomas,Union,Victor,William,Young,Zero";
+
+        public static void Initialize()
+        {
+            var fullPath = Configuration.GetModFileName("genericnames.txt");
+            var unparsedNames = defaultNames;
+
+            try
+            {
+                if (File.Exists(fullPath))
+                {
+                    unparsedNames = File.ReadAllText(fullPath);
+                }
+                else
+                {
+                    Console.Message("No names found, writing default values to " + fullPath);
+                    File.WriteAllText(fullPath, unparsedNames);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error("error reading names from disk " + ex);
+            }
+
+            // split on new lines, commas and semi-colons
+            _names = unparsedNames.Split(new[] { "\n", "\r", ",", ";" }, StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        public static string GetGenericName(int count)
+        {
+            var name = _names[Random.Range(0, _names.Length)];
+            while (count > 1)
+            {
+                name += " " + _names[Random.Range(0, _names.Length)];
+                count--;
+            }
+            return name;
+        }
+    }
+}
+

--- a/AutoLineColor/Naming/LondonNamingStrategy.cs
+++ b/AutoLineColor/Naming/LondonNamingStrategy.cs
@@ -1,0 +1,395 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using ColossalFramework;
+using ColossalFramework.Plugins;
+using Random = UnityEngine.Random;
+
+namespace AutoLineColor.Naming
+{
+    internal class LondonNamingStrategy : INamingStrategy
+    {
+        private static string[] _trains =
+        {
+            "{0}",
+            "{0} Service",
+            "{0} Rail",
+            "{0} Railway",
+            "{0} Flyer",
+            "{0} Zephyr",
+            "{0} Rocket",
+            "{0} Arrow",
+            "{0} Special",
+            "Spirit of {0}",
+            "Pride of {0}",
+        };
+
+        public string GetName(TransportLine transportLine)
+        {
+            switch (transportLine.Info.m_transportType)
+            {
+            case TransportInfo.TransportType.Bus:
+                return GetBusLineName (transportLine);
+            case TransportInfo.TransportType.Metro:
+                return GetMetroLineName (transportLine);
+            default:
+                return GetTrainLineName (transportLine);
+            }
+        }
+
+        private void AnalyzeLine(TransportLine transportLine, List<string> districtNames, out int districtCount, out int stopCount, out bool nonDistrict)
+        {
+            var theNetManager = Singleton<NetManager>.instance;
+            var theDistrictManager = Singleton<DistrictManager>.instance;
+            var stop = transportLine.m_stops;
+            var firstStop = stop;
+            stopCount = 0;
+            districtCount = 0;
+            nonDistrict = false;
+            do
+            {
+                var stopInfo = theNetManager.m_nodes.m_buffer[stop];
+                var district = theDistrictManager.GetDistrict(stopInfo.m_position);
+
+                if (district == 0)
+                {
+                    nonDistrict = true;
+                }
+                else
+                {
+                    var districtName = theDistrictManager.GetDistrictName(district).Trim();
+                    if (!districtNames.Contains(districtName))
+                    {
+                        districtNames.Add(districtName);
+                        districtCount++;
+                    }
+                }
+
+                stop = TransportLine.GetNextStop (stop);
+                stopCount++;
+            } while (stop != firstStop);
+        }
+
+        private static string GetInitials(string words)
+        {
+            string initials = words[0].ToString();
+            for (int i = 0; i < words.Length - 1; i++)
+            {
+                if (words [i] == ' ')
+                {
+                    initials += words[i + 1];
+                }
+            }
+            return initials;
+        }
+
+        private static List<string> GetExistingNames()
+        {
+            var names = new List<string>();
+            var theTransportManager = Singleton<TransportManager>.instance;
+            var theInstanceManager = Singleton<InstanceManager>.instance;
+            var lines = theTransportManager.m_lines.m_buffer;
+            for (ushort lineIndex = 0; lineIndex < lines.Length - 1; lineIndex++)
+            {
+                if (lines[lineIndex].HasCustomName())
+                {
+                    string name = theInstanceManager.GetName(new InstanceID { TransportLine = lineIndex });
+                    if (!String.IsNullOrEmpty(name))
+                    {
+                        names.Add(name);
+                    }
+                }
+            }
+            return names;
+        }
+
+        private static List<string> GetNumbers(List<string> names)
+        {
+            var numbers = new List<string>();
+            foreach (var name in names)
+            {
+                numbers.Add(FirstWord(name));
+            }
+            return numbers;
+        }
+
+        private static string FirstWord(string words)
+        {
+            return words.Contains(" ") ? (words.Substring(0, words.IndexOf(" "))) : words;
+        }
+
+        private static string TryBakerlooify(string word1, string word2)
+        {
+            int offset1 = Math.Min(word1.Length - 1, Math.Max(word1.Length / 2, 4));
+            int offset2 = word2.Length / 4;
+            int length2 = Math.Max(word2.Length / 2, 3);
+
+            string substring2 = word2.Substring(offset2, length2);
+
+            for (int offset = offset1; offset < word1.Length; offset++)
+            {
+                if (substring2.IndexOf(word1[offset]) >= 0)
+                {
+                    return word1.Substring(0, offset) + word2.Substring(offset2 + substring2.IndexOf(word1[offset]));
+                }
+            }
+            return null;
+        }
+
+        /*
+         * Bus line numbers are based on district:
+         *
+         * Given districts "Hamilton Park", "Ivy Square", "King District" in a city called "Springwood", bus line names look like:
+         *
+         * HP43 Local
+         * 22 Hamilton Park
+         * 345 Ivy to King Express
+         * 9 Hamilton, Ivy and King
+         * 6 Springwood Express
+         */
+
+        private string GetBusLineName(TransportLine transportLine)
+        {
+            var districtNames = new List<string>();
+            bool nonDistrict;
+            int districtCount;
+            int stopCount;
+            AnalyzeLine(transportLine, districtNames, out districtCount, out stopCount, out nonDistrict);
+            string prefix = null;
+            int number;
+            string name = null;
+            string suffix = null;
+            var existingNames = GetExistingNames();
+            var existingNumbers = GetNumbers(existingNames);
+
+            // Work out the bus number (and prefix)
+            if (!nonDistrict && districtCount == 1)
+            {
+                /* District Initials */
+                prefix = GetInitials(districtNames[0]);
+                number = 0;
+                string prefixed_number;
+                do
+                {
+                    number++;
+                    prefixed_number = String.Format("{0}{1}", prefix, number);
+                } while (existingNumbers.Contains(prefixed_number));
+            }
+            else
+            {
+                int step;
+                if (stopCount < 15)
+                {
+                    number = Random.Range(100, 900);
+                    step = Random.Range(7, 20);
+                }
+                else if (stopCount < 30)
+                {
+                    number = Random.Range(20, 100);
+                    step = Random.Range(2, 10);
+                }
+                else
+                {
+                    number = Random.Range(1, 20);
+                    step = Random.Range(1, 4);
+                }
+                while (existingNumbers.Contains(number.ToString()))
+                {
+                    number += step;
+                }
+            }
+
+            // Work out the bus name
+            if (districtCount == 1)
+            {
+                name = nonDistrict ? districtNames[0] : "Local";
+            }
+
+            if (districtCount == 2)
+            {
+                name = String.Format("{0} to {1}", FirstWord(districtNames[0]), FirstWord(districtNames[1]));
+            }
+
+            if (districtCount == 3)
+            {
+                name = String.Format("{0}, {1} and {2}",
+                    FirstWord(districtNames[0]), FirstWord(districtNames[1]), FirstWord(districtNames[2]));
+            }
+
+            if (districtCount == 0 || districtCount > 3)
+            {
+                var theSimulationManager = Singleton<SimulationManager>.instance;
+                name = theSimulationManager.m_metaData.m_CityName;
+            }
+
+            if (stopCount <= 4)
+            {
+                suffix = "Express";
+            }
+
+            string lineName = String.Format("{0}{1}", prefix ?? "", number);
+            if (!String.IsNullOrEmpty(name))
+            {
+                lineName += " " + name;
+            }
+            if (!String.IsNullOrEmpty(suffix))
+            {
+                lineName += " " + suffix;
+            }
+            return lineName;
+        }
+
+        /*
+         * Metro line names are based on district, with generic names from a list thrown in.
+         *
+         * Given districts "Manor Park", "Ivy Square", "Hickory District", metro line names look like:
+         *
+         * Manor Line
+         * Ivy Loop Line
+         * Hickory & Ivy Line
+         * Hickory, Manor & Ivy Line
+         * Foxtrot Line
+         *
+         * There's also some attempt to "Bakerlooify" line names.  No idea how well that will work.
+         */
+
+        private string GetMetroLineName(TransportLine transportLine)
+        {
+            var districtNames = new List<string>();
+            bool nonDistrict;
+            int districtCount;
+            int stopCount;
+            AnalyzeLine(transportLine, districtNames, out districtCount, out stopCount, out nonDistrict);
+            string name = null;
+            var districtFirstNames = districtNames.Select(FirstWord).ToList();
+            var existingNames = GetExistingNames();
+            int count = 0;
+
+            if (districtCount == 1)
+            {
+                name = districtNames[0];
+            }
+            else if (districtCount == 2)
+            {
+                if (districtFirstNames[0].Equals(districtFirstNames[1]))
+                {
+                    name = districtFirstNames[0];
+                }
+                else
+                {
+                    name = TryBakerlooify(districtFirstNames[0], districtFirstNames[1]) ??
+                        TryBakerlooify(districtFirstNames[1], districtFirstNames[0]) ??
+                        String.Format("{0} & {1}", districtFirstNames[0], districtFirstNames[1]);
+                }
+            }
+            else if (districtCount >= 3)
+            {
+                int totalLength = districtFirstNames.Sum(d => d.Length);
+                if (totalLength < 20)
+                {
+                    var districtFirstNamesArray = districtFirstNames.ToArray();
+                    name = String.Format("{0} & {1}",
+                        String.Join(", ", districtFirstNamesArray, 0, districtFirstNamesArray.Length - 1),
+                        districtFirstNamesArray[districtFirstNamesArray.Length - 1]);
+                }
+            }
+
+            var lineName = name == null ? "Metro Line" : String.Format("{0} Line", name);
+            while (name == null || existingNames.Contains(lineName))
+            {
+                name = GenericNames.GetGenericName(count / 2);
+                lineName = String.Format("{0} Line", name);
+                count++;
+            }
+            return lineName;
+        }
+
+        /*
+         * Train line names are based on the British designations, with some liberties taken.
+         *
+         * The format is AXNN Name:
+         *
+         * A is the number of districts the train stops at.
+         * X is the first letter of the last district, or X if the train stops outside of a district.
+         * NN are random digits.
+         *
+         * The name is based on the district names.
+         */
+
+        private string GetTrainLineName(TransportLine transportLine)
+        {
+            var districtNames = new List<string>();
+            bool nonDistrict;
+            int districtCount;
+            int stopCount;
+            AnalyzeLine(transportLine, districtNames, out districtCount, out stopCount, out nonDistrict);
+            string ident = null;
+            int number = Random.Range(1, 90);
+            string name = null;
+            var districtFirstNames = districtNames.Select(FirstWord).ToList();
+            var existingNames = GetExistingNames();
+            var existingNumbers = GetNumbers(existingNames);
+
+            var lastDistrictName = districtNames.LastOrDefault();
+            if (String.IsNullOrEmpty(lastDistrictName))
+            {
+                lastDistrictName = "Z";
+            }
+
+            ident = String.Format("{0}{1}", districtCount, nonDistrict ? "X" : lastDistrictName.Substring(0, 1));
+
+            if (districtCount == 0)
+            {
+                var theSimulationManager = Singleton<SimulationManager>.instance;
+                name = String.Format(_trains[Random.Range(0, _trains.Length)], theSimulationManager.m_metaData.m_CityName);
+            }
+            else if (districtCount == 1)
+            {
+                name = String.Format(_trains[Random.Range(0, _trains.Length)], districtNames[0]);
+            }
+            else if (districtCount == 2)
+            {
+                if (districtFirstNames[0].Equals(districtFirstNames[1]))
+                {
+                    name = districtFirstNames[0];
+                }
+                else if (stopCount == 2)
+                {
+                    name = String.Format("{0} {1} Shuttle", districtFirstNames[0], districtFirstNames[1]);
+                }
+                else if (!nonDistrict)
+                {
+                    name = String.Format("{0} {1} Express", districtFirstNames[0], districtFirstNames[1]);
+                }
+                else
+                {
+                    name = String.Format("{0} via {1}", districtFirstNames[0], districtFirstNames[1]);
+                }
+            }
+            else
+            {
+                int totalLength = districtFirstNames.Sum(d => d.Length);
+                if (totalLength < 15)
+                {
+                    var districtFirstNamesArray = districtFirstNames.ToArray();
+                    name = String.Format("{0} and {1} via {2}",
+                        String.Join(", ", districtFirstNamesArray, 0, districtFirstNamesArray.Length - 2),
+                        districtFirstNamesArray[districtFirstNamesArray.Length - 1],
+                        districtFirstNamesArray[districtFirstNamesArray.Length - 2]);
+                }
+                else
+                {
+                    name = String.Format(_trains[Random.Range(0, _trains.Length)], districtNames.First());
+                }
+            }
+
+            var lineNumber = String.Format("{0}{1:00}", ident, number);
+            while (existingNumbers.Contains(lineNumber))
+            {
+                number++;
+                lineNumber = String.Format("{0}{1:00}", ident, number);
+            }
+            return String.Format("{0} {1}", lineNumber, name);
+        }
+    }
+}


### PR DESCRIPTION
I've created a couple of extra strategies, and fixed a few problems I encountered on the way.  Feel free to pull this into your mod, and any comments are welcome.
#### The Categorised Color Strategy

This strategy colorises using a deterministic sequence based on 18 base hues (3 variations on each of the primary and secondary colors).  The next hue is chosen to be reasonably far away from the previous one.
- Buses are pale.  There are 3 levels of paleness, as I tend to have a lot of buses.
- Metro are bright.  There are 2 levels of brightness (full bright, and partly darkened).
- Trains are dark.

Once the colors are exhausted the sequence repeats.
#### The London Naming Strategy

This is a naming strategy inspired by transport naming schemes in London.
- Buses are named like: "9 Aldwych", "33 Elm Heights", "CH4 Local"
- Metro are named like: "Beech Line", "Elm & Oak Line", "Juliet Line"
- Trains are named like: "1X45 Westvalley", "2G42 Elm to Grove", "3J19 Sycamore Rail"
#### Bugfixes/Workarounds

I extended the hack for detecting unmodified colors to metro and train.  I was seeing the same problem with metro, so I assume it's a generic problem.

I changed how IsActive() works.  We do actually care about Hidden and Complete lines.  Lines that are temporarily not shown by the GUI still have colors and we should avoid duplicating.  Similarly, a loaded save seems to have all the lines marked as Complete but not Created.

You might want to check neither of these have any adverse effects on other code.
